### PR TITLE
Cap Documenter to v0.19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ notifications:
 
 after_success:
 # Compile documentation
-- julia -e 'Pkg.add("Documenter")'
+- julia -e 'using Pkg; ps=PackageSpec(name="Documenter", version="0.19"); Pkg.add(ps); Pkg.pin(ps)'
 - julia -e 'cd(Pkg.dir("BeaData")); include(joinpath("docs", "make.jl"))'
 # push coverage results to Coveralls
 - julia -e 'cd(Pkg.dir("BeaData")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'


### PR DESCRIPTION
Due to upcoming breaking changes in Documenter. This makes sure that the doc builds do not start failing when 0.20 lands in METADATA. [See this thread on Discourse for more information.](https://discourse.julialang.org/t/psa-documenter-jl-breaking-changes-version-capping/16431) 

Ref: JuliaDocs/Documenter.jl#861